### PR TITLE
Fix Vercel production build

### DIFF
--- a/utkcc-fe/app/(subpages)/about/aboutImage.tsx
+++ b/utkcc-fe/app/(subpages)/about/aboutImage.tsx
@@ -2,12 +2,12 @@
 
 import Image from 'next/image';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import groupImage from '/public/assets/images/utkcc.jpeg';
+import groupImage from 'public/assets/images/utkcc.jpeg';
 
 export default function AboutImage() {
   const [isLightboxMounted, setIsLightboxMounted] = useState(false);
   const [isLightboxVisible, setIsLightboxVisible] = useState(false);
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
 
   const openLightbox = () => {
     if (closeTimerRef.current) window.clearTimeout(closeTimerRef.current);

--- a/utkcc-fe/app/(subpages)/about/aboutModal.tsx
+++ b/utkcc-fe/app/(subpages)/about/aboutModal.tsx
@@ -29,7 +29,7 @@ function AboutModal({
   setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const [isVisible, setIsVisible] = useState(false);
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
 
   const closeModal = useCallback(() => {
     setIsVisible(false);

--- a/utkcc-fe/app/(subpages)/events/eventsHomeIntro.tsx
+++ b/utkcc-fe/app/(subpages)/events/eventsHomeIntro.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import eventsImage from '/public/assets/images/events-image.png';
+import eventsImage from 'public/assets/images/events-image.png';
 import Link from 'next/link';
 
 export default function EventsHomeIntro() {

--- a/utkcc-fe/app/(subpages)/resources/page.tsx
+++ b/utkcc-fe/app/(subpages)/resources/page.tsx
@@ -3,12 +3,12 @@ import Image from 'next/image';
 import Link from 'next/link';
 import PageIntro from '@/components/pageIntro';
 import MenuBar from '@/components/menubar';
-import antiCalendarImage from '@/public/assets/images/resources/anti-calendar.jpeg';
-import studyPackageImage from '@/public/assets/images/resources/study-package.jpeg';
-import instagramLogo from '@/public/assets/images/media-logo/instagram.png';
-import facebookLogo from '@/public/assets/images/media-logo/facebook.png';
-import linkedInLogo from '@/public/assets/images/media-logo/linkedIn.png';
-import youtubeLogo from '@/public/assets/images/media-logo/youtube.png';
+import antiCalendarImage from 'public/assets/images/resources/anti-calendar.jpeg';
+import studyPackageImage from 'public/assets/images/resources/study-package.jpeg';
+import instagramLogo from 'public/assets/images/media-logo/instagram.png';
+import facebookLogo from 'public/assets/images/media-logo/facebook.png';
+import linkedInLogo from 'public/assets/images/media-logo/linkedIn.png';
+import youtubeLogo from 'public/assets/images/media-logo/youtube.png';
 import { joinMemberShipLink } from '@/data/change-annually-data';
 
 export const metadata: Metadata = {

--- a/utkcc-fe/app/layout.tsx
+++ b/utkcc-fe/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import localFont from 'next/font/local';
+import Script from 'next/script';
 import FooterContactInfo from '@/components/footerContactInfo';
 import FooterVisibility from '@/components/footerVisibility';
 import ChatWidget from '@/components/ChatWidget';
@@ -122,20 +123,20 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={gMarket.className}>
-      <head>
-        <script
-          type="module"
-          src="https://unpkg.com/ionicons@7/dist/ionicons/ionicons.esm.js"
-        ></script>
-        <script
-          noModule
-          src="https://unpkg.com/ionicons@7/dist/ionicons/ionicons.js"
-        ></script>
-      </head>
       <body
         className="w-[100dvw] min-h-[100lvh]"
         // suppressHydrationWarning={true}
       >
+        <Script
+          type="module"
+          src="https://unpkg.com/ionicons@7/dist/ionicons/ionicons.esm.js"
+          strategy="afterInteractive"
+        />
+        <Script
+          noModule
+          src="https://unpkg.com/ionicons@7/dist/ionicons/ionicons.js"
+          strategy="afterInteractive"
+        />
         {children}
         <FooterVisibility>
           <FooterContactInfo />

--- a/utkcc-fe/components/navbar.tsx
+++ b/utkcc-fe/components/navbar.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useState, useEffect, useRef } from 'react';
 import './navbar.css';
 import { handleScroll } from '@/lib/utils';
-import SmallLogoImage from '@/public/assets/images/logo-nav.png';
+import SmallLogoImage from 'public/assets/images/logo-nav.png';
 import { recruitmentLink } from '@/data/change-annually-data';
 
 export default function NavBar({

--- a/utkcc-fe/tsconfig.json
+++ b/utkcc-fe/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -38,6 +38,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "web"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the Vercel production build failure after the latest UI merge.

## Changes

- Updated public asset imports so Vercel/Turbopack can resolve images correctly
- Excluded the nested `web` submodule from TypeScript checks
- Fixed browser timeout ref types in the About image/modal components
- Replaced raw Ionicons script tags with `next/script`

## Verification

- `npm run build` passes locally