### PR TITLE
Refresh site content and Course Map experience

### DIFF
--- a/utkcc-fe/app/globals.css
+++ b/utkcc-fe/app/globals.css
@@ -118,6 +118,10 @@
 
 .course-map-sheet-stack {
   animation: course-map-stack-cycle 12s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+  animation-fill-mode: both;
+  backface-visibility: hidden;
+  transform-origin: center center;
+  contain: paint;
   will-change: opacity, transform;
 }
 
@@ -125,14 +129,14 @@
   z-index: 2;
   opacity: 0.86;
   transform: translate3d(30px, 13px, 0) rotate(3.2deg) scale(0.96);
-  animation-delay: 4s;
+  animation-delay: -8s;
 }
 
 .course-map-sheet-3 {
   z-index: 1;
   opacity: 0.68;
   transform: translate3d(-30px, 22px, 0) rotate(-3.2deg) scale(0.92);
-  animation-delay: 8s;
+  animation-delay: -4s;
 }
 
 .sponsor-marquee-track {


### PR DESCRIPTION
## Summary

- refresh the newsletter experience around the `utkccmedia` Instagram account and weekly post format
- redesign the Resources page with a Course Map product overview, three-page PDF preview, early-bird pricing, and Google Form purchase flow
- rebuild the sponsor presentation as a cleaner continuously scrolling partner showcase
- simplify and restyle the footer social links and contact layout
- make chatbot URLs clickable and prevent long links from overflowing message bubbles
- update site metadata and the freshman seminar knowledge-base content

## Why

The site content and interaction patterns had fallen behind the current UTKCC newsletter, Course Map, sponsor, and freshman seminar offerings. This refresh aligns those pages with the latest programs and improves mobile presentation and navigation.

## Impact

- visitors can discover weekly newsletter posts through Instagram
- students can preview Course Map sample pages and reach the purchase form directly
- sponsor logos and links are easier to browse across viewport sizes
- chatbot answers containing URLs remain readable and actionable
- footer and responsive layouts are more consistent with the site visual system

## Validation

- `npx tsc --noEmit`
- Course Map sample PDF rendered and verified as a three-page document
- local `.env` removed from Git history and added to `.gitignore`

## Security note

GitHub push protection initially detected an OpenAI key in a committed `.env` file. The file was removed from the amended commit before the branch was pushed. The local `.env` remains untracked; the exposed key should still be rotated as a precaution.
